### PR TITLE
fix total count

### DIFF
--- a/src/main/java/dict/build/FastBuilder.java
+++ b/src/main/java/dict/build/FastBuilder.java
@@ -471,11 +471,14 @@ public class FastBuilder {
 
 			String line = null;
 			long total = 0;
+			long epoch = 0;
 			while (null != (line = fr.readLine())) {
 				String[] seg = line.split("\t");
 				if (seg.length < 3) continue;
 				tree.put(seg[0], Integer.parseInt(seg[1]));
-				total += 1;
+				epoch += 1;
+				//all single char's frequency
+				if(seg[0].length()<2) total += Integer.parseInt(seg[1]);
 				if (total % 1000 == 0) {
 					LOG.info("load freq to radix tree done: " + total);
 				}

--- a/src/main/java/dict/build/FastBuilder.java
+++ b/src/main/java/dict/build/FastBuilder.java
@@ -479,7 +479,7 @@ public class FastBuilder {
 				epoch += 1;
 				//all single char's frequency
 				if(seg[0].length()<2) total += Integer.parseInt(seg[1]);
-				if (total % 1000 == 0) {
+				if (epoch % 1000 == 0) {
 					LOG.info("load freq to radix tree done: " + total);
 				}
 			}


### PR DESCRIPTION
做了两个实验：
实验一：语料是同一句话重复100次，每句话长度为72， before： dict.build.FastBuilder -total word requence is: 304；after fixed:dict.build.FastBuilder -total word requence is: 7100.而total的值不是72*100的原因是使用的是后缀频率，所以每句话末尾的字会少算一次，及72*100-100；这个误差较小，可以接受。结果：before为空，after： 客户	400	4.08746284125034	2.0
实验二：语料增加，用一份十万语料数据测试，min_e设置为5.0，结果：before比after多74个，这74个词中有51个是“非词”，如“操作负责”，“机构完成”等
